### PR TITLE
FIX: apply default name over Invalid, the default default.

### DIFF
--- a/lcls-twincat-common-components/Library/POUs/FB_PositionState_Defaults.TcPOU
+++ b/lcls-twincat-common-components/Library/POUs/FB_PositionState_Defaults.TcPOU
@@ -14,7 +14,7 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[IF stPositionState.sName = '' THEN
+      <ST><![CDATA[IF stPositionState.sName = '' OR stPositionState.sName = 'Invalid' THEN
     stPositionState.sName := sNameDefault;
 END_IF
 IF stPositionState.fVelocity = 0 THEN


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Several times in this repo, I rely on this function block to set default names e.g. "OUT", "TARGET1", with checks to make sure that I don't override custom names that the PLC code writer has chosen to use.

Previously, this checked name against empty string- non-empty names should not be replaced.
This also allows us to replace "Invalid", which is the default value of the name field on `ST_PositionState`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
pmps db refuses to load parameters for states that have "Invalid" as their name, as a guard against errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This worked for TMO in https://github.com/pcdshub/lcls-plc-tmo-motion/pull/95 and is currently installed as version 0.0.0 on the programming node.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
