### PR TITLE
BUG: the analog ADC is presented in 15 bits

### DIFF
--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM.TcPOU
@@ -90,7 +90,7 @@ VAR
     fbGige: FB_PPM_Gige;
 
     {attribute 'pytmc' :='pv: FWM'}
-    fbFlowMeter: FB_AnalogInput := (iTermBits:=12, fTermMax:=60, fTermMin:=0, fResolution:=0.1);
+    fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
 
     {attribute 'pytmc' := 'pv: YAG'}
     fbYagThermoCouple: FB_ThermoCouple;

--- a/lcls-twincat-common-components/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-common-components/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_common_components : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    stLibVersion_lcls_twincat_common_components : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 1, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-common-components/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-common-components/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_common_components_nrw : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    stLibVersion_lcls_twincat_common_components : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-common-components/Library/Version/Global_Version.TcGVL
+++ b/lcls-twincat-common-components/Library/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_common_components : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 1, sVersion := '0.0.0');
+    stLibVersion_lcls_twincat_common_components_nrw : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- PPM analog flow meter scaling update.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- EL3052 uses 15 bit presentation. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested on multiple fdq flow meters in TMO


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-1248
## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
