### PR TITLE
Add an FB for FDQ flow meter

### DIFF
--- a/lcls-twincat-common-components/Library/Library.plcproj
+++ b/lcls-twincat-common-components/Library/Library.plcproj
@@ -123,6 +123,9 @@
     <Compile Include="POUs\FB_CheckPositionStateWrite.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\FB_FDQ_FlowMeter.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\FB_XTES_Flowswitch.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls-twincat-common-components/Library/POUs/FB_FDQ_FlowMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/POUs/FB_FDQ_FlowMeter.TcPOU
@@ -1,21 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_FDQ_FlowMeter" Id="{b5b12a66-8d5f-455f-b8d1-7dfb923b9d24}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK FB_FDQ_FlowMeter
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_FDQ_FlowMeter EXTENDS FB_AnalogInput
 VAR_INPUT
 END_VAR
 VAR_OUTPUT
-END_VAR
-VAR
     {attribute 'pytmc' := '
         pv: FWM
         field: EGU lpm
     '}
-    fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
+    fFlow : LREAL;
+END_VAR
+VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[fbFlowMeter();]]></ST>
+      <ST><![CDATA[SUPER^(iTermBits:=15, fTermMax:=60, fTermMin:=0);
+fFlow := SUPER^.fReal;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-common-components/Library/POUs/FB_FDQ_FlowMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/POUs/FB_FDQ_FlowMeter.TcPOU
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_FDQ_FlowMeter" Id="{b5b12a66-8d5f-455f-b8d1-7dfb923b9d24}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_FDQ_FlowMeter
+VAR_INPUT
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+    {attribute 'pytmc' := '
+        pv: FWM
+        field: EGU lpm
+    '}
+    fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbFlowMeter();]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- add an FB for FDQ flow meter `FB_FDQ_FlowMeter`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keyence flow meters for now are all using the same parameters. In the future, they may need support for other than a 15 bit ADC.
This should make it easier to set all the sensors units and thresholds from one spot if needed.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running on TMO motion.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
