### PR TITLE
FB_FDQ_FlowMeter more pragmatic

### DIFF
--- a/lcls-twincat-common-components/Library/POUs/FB_FDQ_FlowMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/POUs/FB_FDQ_FlowMeter.TcPOU
@@ -1,22 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_FDQ_FlowMeter" Id="{b5b12a66-8d5f-455f-b8d1-7dfb923b9d24}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK FB_FDQ_FlowMeter EXTENDS FB_AnalogInput
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_FDQ_FlowMeter
 VAR_INPUT
+    // Connect this input to the terminal
+    iRaw AT %I*: INT;
+    // The number of bits correlated with the terminal's max value. This is not necessarily the resolution parameter.
+    iTermBits: UINT := 15;
+    // The fReal value correlated with the terminal's max value
+    fTermMax: LREAL := 60;
+    // The fReal value correlated with the terminal's min value
+    fTermMin: LREAL := 0;
+    // Value to scale the end result to
+    fResolution : LREAL := 1;
+    fOffset : LREAL;
 END_VAR
 VAR_OUTPUT
     {attribute 'pytmc' := '
         pv: FWM
         field: EGU lpm
     '}
-    fFlow : LREAL;
+    fbFlowMeter : FB_AnalogInput;
 END_VAR
 VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[SUPER^(iTermBits:=15, fTermMax:=60, fTermMin:=0);
-fFlow := SUPER^.fReal;]]></ST>
+      <ST><![CDATA[fbFlowMeter(iRaw := iRaw,
+iTermBits:=iTermBits,
+fTermMax:=fTermMax,
+fTermMin:=fTermMin,
+fResolution:=fResolution,
+fOffset:=fOffset
+);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Drop inheritance and wrap `FB_AnalogInput` instead.
- Makes PV names automatically consistent.
- Backward compatible with the 2 current uses of this FB.
- Passes all inputs in the case someone wants to override.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Make PV names consistent.
- Inherited FBs lose all parent PVs.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I tested this on a test plc and IOC.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
