### PR TITLE
Fixing PPM indexing bug

### DIFF
--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
@@ -214,7 +214,7 @@ IF rTrig_Background.Q OR bResetAutoBackground THEN
         // Dump 5s worth of readings
         IF udBackgroundVoltageBufferIndex > 6 THEN
             FOR i := (udBackgroundVoltageBufferIndex - 5) TO (udBackgroundVoltageBufferIndex - 1) DO
-                fBackgroundVoltageSum := fBackgroundVoltageSum - fBackgroundVoltageBuffer[i MOD 100];
+                fBackgroundVoltageSum := fBackgroundVoltageSum - fBackgroundVoltageBuffer[((i-1) MOD 100) + 1];
             END_FOR
             udBackgroundVoltageBufferIndex := udBackgroundVoltageBufferIndex - 5;
             IF udBackgroundVoltageBufferIndex <> 1 AND BACKGROUND_MODE = Passive THEN
@@ -233,8 +233,8 @@ ELSIF eEnumGet = E_PPM_States.OUT AND stYAxisState = 0 THEN
     // Every second, move fBackgroundVoltageAcc into buffer and sum
     IF tonBackgroundAutoCollecting.Q = TRUE THEN
         tonBackgroundAutoCollecting( IN := FALSE);
-        fBackgroundVoltageStale := fBackgroundVoltageBuffer[udBackgroundVoltageBufferIndex MOD 100];
-        fBackgroundVoltageBuffer[udBackgroundVoltageBufferIndex MOD 100] := fBackgroundVoltageAcc / uAccCount;
+        fBackgroundVoltageStale := fBackgroundVoltageBuffer[((udBackgroundVoltageBufferIndex - 1) MOD 100) + 1];
+        fBackgroundVoltageBuffer[((udBackgroundVoltageBufferIndex - 1) MOD 100) + 1] := fBackgroundVoltageAcc / uAccCount;
         // Remove overwritten voltage
         IF udBackgroundVoltageBufferIndex > 100 THEN
             fBackgroundVoltageSum := fBackgroundVoltageSum - fBackgroundVoltageStale;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Yesterday, plc-kfe-rix-motion was crashing due to a page fault. I believe this was because of the way I was indexing into fBackgroundVoltageBuffer, which uses one-based indexing. I am using a new expression to index - ((index-1) MOD 100) + 1. The result of MOD 100 is always between 0 and 99, and adding one means the range is between one and a hundred inclusive, inclusive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Currently running on plc-kfe-rix-motion without crashing

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
