### PR TITLE
FIX: fix fault polarity and add device name

### DIFF
--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
@@ -315,7 +315,8 @@ fCalibMJ := SEL(fFrequency <> 0, -9999, fPulseWattage / fFrequency);
         uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
     END_CASE
 {END_IF}
-FFO(i_xOK := bOverAllowableEnergy,
+FFO(i_xOK := NOT bOverAllowableEnergy,
+    i_DevName := sDeviceName,
     io_fbFFHWO := fbFFHWO);
 
 // Buffer the full-rate Voltage, Pulse wattage, and calibrated MJ values


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Two small things we missed in review of #69:
- Fix so that the PPM is OK when the wattage is not high (instead, we were faulting on when the device was good)
- Add the device name to the fault for display in the PMPS-UI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Minor things noticed while prepping for rix beam

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Soon, interactively in rix plc

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
