### PR TITLE
Powermeter fast-fault edits

### DIFF
--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
@@ -304,12 +304,12 @@ fCalibMJ := SEL(fFrequency <> 0, -9999, fPulseWattage / fFrequency);
         uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
     END_CASE
 {END_IF}
-IF eEnumGet <> E_PPM_States.OUT AND bOverAllowableEnergy THEN
-    uOverCounter := MIN(uOverCounter + 2, 50);
+IF eEnumGet = E_PPM_States.POWERMETER AND bOverAllowableEnergy THEN
+    uOverCounter := MIN(uOverCounter + 1, 10);
 ELSE
-    uOverCounter := MAX(uOverCounter - 1, 1);
+    uOverCounter := 0;
 END_IF
-FF(i_xOK := eEnumGet = E_PPM_States.OUT OR uOverCounter < 50,
+FF(i_xOK := eEnumGet <> E_PPM_States.POWERMETER OR uOverCounter < 10,
     i_DevName := sDeviceName,
     io_fbFFHWO := fbFFHWO);
 

--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
@@ -160,10 +160,11 @@ VAR
     fbPulseWattageBuffer: FB_LREALBuffer;
     fbCalibMJBuffer: FB_LREALBuffer;
 
-    FFO: FB_FastFault :=(
+    FF: FB_FastFault :=(
         i_Desc := 'Fault occurs when the per-pulse energy reading is high enough to damage the power meter',
         i_TypeCode := 16#500);
     bOverAllowableEnergy: BOOL;
+    uOverCounter: UINT := 1;
 END_VAR
 VAR_STAT CONSTANT
     // Voltage limits for wavelength ranges
@@ -287,27 +288,30 @@ END_IF
 fPulseWattage := SEL(fResponsivity <> 0, 0, (fVoltage - fBackgroundVoltage) / fResponsivity);
 fCalibMJ := SEL(fFrequency <> 0, -9999, fPulseWattage / fFrequency);
 
-// FF in case voltage is high enough to damage power meter based on wavelength
-IF rTrig_Background.Q THEN
-    {IF defined (K)}
-        CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
-            0 .. uSoftWavelengthEdge1L: bOverAllowableEnergy := fCalibMJ > 2;
-            uSoftWavelengthEdge1 .. uSoftWavelengthEdge2L : bOverAllowableEnergy := fCalibMJ > 2;
-            uSoftWavelengthEdge2 .. uSoftWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
-            uSoftWavelengthEdge3 .. uSoftWavelengthEdge4L: bOverAllowableEnergy := fCalibMJ > 0.5;
-            uSoftWavelengthEdge4 .. 65535: bOverAllowableEnergy := fCalibMJ > 1;
-        END_CASE
-    {ELSIF defined (L)}
-        CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
-            uHardWavelengthEdge1 .. uHardWavelengthEdge2L: bOverAllowableEnergy := fCalibMJ > 10;
-            uHardWavelengthEdge2 .. uHardWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
-            uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
-        END_CASE
-    {END_IF}
-    FFO(i_xOK := NOT bOverAllowableEnergy,
-        i_DevName := sDeviceName,
-        io_fbFFHWO := fbFFHWO);
+// FF in case voltage is high enough to damage power meter based on wavelengths
+{IF defined (K)}
+    CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
+        0 .. uSoftWavelengthEdge1L: bOverAllowableEnergy := fCalibMJ > 2;
+        uSoftWavelengthEdge1 .. uSoftWavelengthEdge2L : bOverAllowableEnergy := fCalibMJ > 2;
+        uSoftWavelengthEdge2 .. uSoftWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
+        uSoftWavelengthEdge3 .. uSoftWavelengthEdge4L: bOverAllowableEnergy := fCalibMJ > 0.5;
+        uSoftWavelengthEdge4 .. 65535: bOverAllowableEnergy := fCalibMJ > 1;
+    END_CASE
+{ELSIF defined (L)}
+    CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
+        uHardWavelengthEdge1 .. uHardWavelengthEdge2L: bOverAllowableEnergy := fCalibMJ > 10;
+        uHardWavelengthEdge2 .. uHardWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
+        uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
+    END_CASE
+{END_IF}
+IF eEnumGet <> E_PPM_States.OUT AND bOverAllowableEnergy = TRUE THEN
+    uOverCounter := MIN(uOverCounter + 2, 50);
+ELSE
+    uOverCounter := MAX(uOverCounter - 1, 1);
 END_IF
+FF(i_xOK := eEnumGet = E_PPM_States.OUT OR uOverCounter < 50,
+    i_DevName := sDeviceName,
+    io_fbFFHWO := fbFFHWO);
 
 // Buffer the full-rate Voltage, Pulse wattage, and calibrated MJ values
 fbVoltageBuffer(

--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
@@ -304,7 +304,7 @@ fCalibMJ := SEL(fFrequency <> 0, -9999, fPulseWattage / fFrequency);
         uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
     END_CASE
 {END_IF}
-IF eEnumGet <> E_PPM_States.OUT AND bOverAllowableEnergy = TRUE THEN
+IF eEnumGet <> E_PPM_States.OUT AND bOverAllowableEnergy THEN
     uOverCounter := MIN(uOverCounter + 2, 50);
 ELSE
     uOverCounter := MAX(uOverCounter - 1, 1);

--- a/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
+++ b/lcls-twincat-common-components/Library/Devices/PPM/FB_PPM_PowerMeter.TcPOU
@@ -288,24 +288,26 @@ fPulseWattage := SEL(fResponsivity <> 0, 0, (fVoltage - fBackgroundVoltage) / fR
 fCalibMJ := SEL(fFrequency <> 0, -9999, fPulseWattage / fFrequency);
 
 // FF in case voltage is high enough to damage power meter based on wavelength
-{IF defined (K)}
-    CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
-        0 .. uSoftWavelengthEdge1L: bOverAllowableEnergy := fCalibMJ > 2;
-        uSoftWavelengthEdge1 .. uSoftWavelengthEdge2L : bOverAllowableEnergy := fCalibMJ > 2;
-        uSoftWavelengthEdge2 .. uSoftWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
-        uSoftWavelengthEdge3 .. uSoftWavelengthEdge4L: bOverAllowableEnergy := fCalibMJ > 0.5;
-        uSoftWavelengthEdge4 .. 65535: bOverAllowableEnergy := fCalibMJ > 1;
-    END_CASE
-{ELSIF defined (L)}
-    CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
-        uHardWavelengthEdge1 .. uHardWavelengthEdge2L: bOverAllowableEnergy := fCalibMJ > 10;
-        uHardWavelengthEdge2 .. uHardWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
-        uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
-    END_CASE
-{END_IF}
-FFO(i_xOK := NOT bOverAllowableEnergy,
-    i_DevName := sDeviceName,
-    io_fbFFHWO := fbFFHWO);
+IF rTrig_Background.Q THEN
+    {IF defined (K)}
+        CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
+            0 .. uSoftWavelengthEdge1L: bOverAllowableEnergy := fCalibMJ > 2;
+            uSoftWavelengthEdge1 .. uSoftWavelengthEdge2L : bOverAllowableEnergy := fCalibMJ > 2;
+            uSoftWavelengthEdge2 .. uSoftWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
+            uSoftWavelengthEdge3 .. uSoftWavelengthEdge4L: bOverAllowableEnergy := fCalibMJ > 0.5;
+            uSoftWavelengthEdge4 .. 65535: bOverAllowableEnergy := fCalibMJ > 1;
+        END_CASE
+    {ELSIF defined (L)}
+        CASE REAL_TO_UINT(PMPS_GVL.stCurrentBeamParameters.neV) OF
+            uHardWavelengthEdge1 .. uHardWavelengthEdge2L: bOverAllowableEnergy := fCalibMJ > 10;
+            uHardWavelengthEdge2 .. uHardWavelengthEdge3L: bOverAllowableEnergy := fCalibMJ > 4;
+            uHardWavelengthEdge3 .. 65535: bOverAllowableEnergy := fCalibMJ > 10;
+        END_CASE
+    {END_IF}
+    FFO(i_xOK := NOT bOverAllowableEnergy,
+        i_DevName := sDeviceName,
+        io_fbFFHWO := fbFFHWO);
+END_IF
 
 // Buffer the full-rate Voltage, Pulse wattage, and calibrated MJ values
 fbVoltageBuffer(

--- a/lcls-twincat-common-components/lcls-twincat-common-components.tsproj
+++ b/lcls-twincat-common-components/lcls-twincat-common-components.tsproj
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" TcVersionFixed="true">
-	<Project ProjectGUID="{AB70FBBB-83F0-4609-9FD5-DF42CB839A31}" TargetNetId="172.21.140.70.1.1" Target64Bit="true" ShowHideConfigurations="#x3c6">
+	<Project ProjectGUID="{AB70FBBB-83F0-4609-9FD5-DF42CB839A31}" Target64Bit="true" ShowHideConfigurations="#x3c6">
 		<System>
 			<Tasks>
 				<Task Id="5" Priority="20" CycleTime="100000" AmsPort="350" AdtTasks="true">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Only fast-fault if ppm is not out or moving

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Power meters in rix are fast faulting even when beam energy should not be high enough to trigger them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
